### PR TITLE
✨ Update: 챔피언 및 아이템 카드의 스타일 조정으로 중앙 정렬 및 그리드 간격 개선

### DIFF
--- a/src/components/champions/ChampionsCard.tsx
+++ b/src/components/champions/ChampionsCard.tsx
@@ -14,7 +14,7 @@ const ChampionsCard = ({ champion }: { champion: ChampionBasic }) => {
           src={`${CHAMPION_IMG_URL}/${champion.image.full}`}
           alt={champion.name}
           loading="lazy"
-          className="bg-[#767a79]"
+          className="bg-[#767a79] my-0 mx-auto"
         />
         <p className="text-[#dedede] text-xl my-4">{champion.name}</p>
         <p className="text-[#aeaeae]">{champion.title}</p>

--- a/src/components/champions/ChampionsDetailClient.tsx
+++ b/src/components/champions/ChampionsDetailClient.tsx
@@ -109,7 +109,7 @@ const ChampionDetailClient = () => {
               <h2 className="text-xl font-semibold text-[#222] mb-4">
                 Combat Statistics
               </h2>
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-4">
                 <div className="text-[#4A4E4D]">
                   <p className="flex justify-between">
                     <span>Health:</span>

--- a/src/components/items/ItemCard.tsx
+++ b/src/components/items/ItemCard.tsx
@@ -12,7 +12,7 @@ const ItemCard = ({ item }: { item: Item }) => {
         src={`${ITEMS_URL}/${item.image.full}`}
         alt={item.name}
         loading="lazy"
-        className="bg-[#767a79]"
+        className="bg-[#767a79] my-0 mx-auto"
       />
       <p className="text-[#dedede] text-xl my-4">{item.name}</p>
       <p className="text-[#aeaeae]">{item.plaintext}</p>


### PR DESCRIPTION
## 📝 작업 내용

> 카드별 모바일 사이즈 시 이미지 가운데 정렬화

> 그리드 레이아웃 간격 개선